### PR TITLE
Add GitHub CLI to install scripts

### DIFF
--- a/Terminal/install_macos.sh
+++ b/Terminal/install_macos.sh
@@ -29,6 +29,10 @@ brew install htop
 echo "Installing AWS CLI..."
 brew install awscli
 
+# Install GitHub CLI
+echo "Installing GitHub CLI..."
+brew install gh
+
 # Install Podman
 echo "Installing Podman..."
 brew install podman

--- a/Terminal/install_ubuntu24.sh
+++ b/Terminal/install_ubuntu24.sh
@@ -37,6 +37,14 @@ unzip -q awscliv2.zip
 sudo ./aws/install --update
 rm -rf awscliv2.zip aws
 
+# Install GitHub CLI
+echo "Installing GitHub CLI..."
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+sudo apt-get update
+sudo apt-get install -y gh
+
 # Install Podman
 echo "Installing Podman..."
 sudo apt-get install -y podman


### PR DESCRIPTION
## Background
This change adds the GitHub CLI to the macOS and Ubuntu installation scripts.

## Changes
- **`Terminal/install_macos.sh`**: Added `brew install gh` to install the GitHub CLI using Homebrew.
- **`Terminal/install_ubuntu24.sh`**: Added steps to install the GitHub CLI using the official GitHub repository and GPG key. This includes:
    - Downloading and adding the GPG key to `/usr/share/keyrings/githubcli-archive-keyring.gpg`.
    - Adding the GitHub CLI stable repository to `/etc/apt/sources.list.d/github-cli.list`.
    - Running `sudo apt-get update` and `sudo apt-get install -y gh`.

## Testing
- [ ] Verify GitHub CLI is installed successfully on a fresh macOS environment.
- [ ] Verify GitHub CLI is installed successfully on a fresh Ubuntu 24.04 environment.
- [ ] Run `gh --version` on both platforms to confirm installation.
