### PR TITLE
Add shared Node.js PATH helper and ensure NVM availability

### DIFF
--- a/ClaudeCode/install_hooks.sh
+++ b/ClaudeCode/install_hooks.sh
@@ -23,6 +23,10 @@ NC='\033[0m' # No Color
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 SHARED_DIR="$REPO_DIR/shared"
+
+# Ensure Node.js is in PATH (sources NVM/fnm if needed)
+# shellcheck source=../shared/ensure_node.sh
+source "$SHARED_DIR/ensure_node.sh"
 HOOK_SCRIPT="$SCRIPT_DIR/hooks/post_code_hook.sh"
 TASK_HOOK_SCRIPT="$SCRIPT_DIR/hooks/post_task_hook.sh"
 

--- a/ClaudeCode/install_skills.sh
+++ b/ClaudeCode/install_skills.sh
@@ -10,6 +10,13 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SHARED_DIR="$(cd "$SCRIPT_DIR/.." && pwd)/shared"
+
+# Ensure Node.js is in PATH (sources NVM/fnm if needed)
+# shellcheck source=../shared/ensure_node.sh
+if [ -f "$SHARED_DIR/ensure_node.sh" ]; then
+    . "$SHARED_DIR/ensure_node.sh"
+fi
 
 printf "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
 printf "${GREEN}Claude Code Skills & MCP Installer${NC}\n"

--- a/Kiro/install_hooks.sh
+++ b/Kiro/install_hooks.sh
@@ -23,6 +23,10 @@ NC='\033[0m' # No Color
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 SHARED_DIR="$REPO_DIR/shared"
+
+# Ensure Node.js is in PATH (sources NVM/fnm if needed)
+# shellcheck source=../shared/ensure_node.sh
+source "$SHARED_DIR/ensure_node.sh"
 HOOK_SCRIPT="$SCRIPT_DIR/hooks/post_code_hook.sh"
 TASK_HOOK_SCRIPT="$SCRIPT_DIR/hooks/post_task_hook.sh"
 

--- a/Kiro/install_mcps.sh
+++ b/Kiro/install_mcps.sh
@@ -36,6 +36,13 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SHARED_DIR="$(cd "$SCRIPT_DIR/.." && pwd)/shared"
+
+# Ensure Node.js is in PATH (sources NVM/fnm if needed)
+# shellcheck source=../shared/ensure_node.sh
+source "$SHARED_DIR/ensure_node.sh"
+
 echo -e "${GREEN}Installing MCP Server Packages for Kiro CLI...${NC}\n"
 echo -e "${BLUE}Agents use per-agent MCP configs. This script installs the npm/Python${NC}"
 echo -e "${BLUE}packages so they're available when agents launch MCP servers via npx/uvx.${NC}\n"

--- a/OpenCode/install_hooks.sh
+++ b/OpenCode/install_hooks.sh
@@ -28,6 +28,10 @@ NC='\033[0m' # No Color
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 SHARED_DIR="$REPO_DIR/shared"
+
+# Ensure Node.js is in PATH (sources NVM/fnm if needed)
+# shellcheck source=../shared/ensure_node.sh
+source "$SHARED_DIR/ensure_node.sh"
 HOOK_SCRIPT="$SCRIPT_DIR/hooks/post_code_hook.sh"
 TASK_HOOK_SCRIPT="$SCRIPT_DIR/hooks/post_task_hook.sh"
 HOOK_PLUGIN="$SCRIPT_DIR/hooks/post_code_hook_plugin.mjs"

--- a/OpenCode/install_mcps.sh
+++ b/OpenCode/install_mcps.sh
@@ -8,6 +8,13 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SHARED_DIR="$(cd "$SCRIPT_DIR/.." && pwd)/shared"
+
+# Ensure Node.js is in PATH (sources NVM/fnm if needed)
+# shellcheck source=../shared/ensure_node.sh
+source "$SHARED_DIR/ensure_node.sh"
+
 echo -e "${GREEN}Installing Model Context Protocol (MCP) Servers for OpenCode...${NC}\n"
 
 # Check for required dependencies

--- a/Terminal/install_macos.sh
+++ b/Terminal/install_macos.sh
@@ -52,10 +52,24 @@ brew install podman
 
 # Install NVM
 echo "Installing NVM..."
+# Ensure .zshrc exists so the NVM installer can append to it
+touch "$HOME/.zshrc"
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 export NVM_DIR="$HOME/.nvm"
 # shellcheck source=/dev/null
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+# Ensure NVM is loaded in .zshrc (the installer may only update .bashrc)
+if ! grep -q 'NVM_DIR' "$HOME/.zshrc" 2>/dev/null; then
+    cat >> "$HOME/.zshrc" << 'NVMEOF'
+
+# NVM (Node Version Manager)
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+NVMEOF
+    echo "Added NVM configuration to ~/.zshrc"
+fi
 
 # Install Node.js 22 via NVM
 echo "Installing Node.js 22 via NVM..."

--- a/Terminal/install_ubuntu24.sh
+++ b/Terminal/install_ubuntu24.sh
@@ -56,6 +56,18 @@ export NVM_DIR="$HOME/.nvm"
 # shellcheck source=/dev/null
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
+# Ensure NVM is loaded in .zshrc if zsh is installed
+if [ -f "$HOME/.zshrc" ] && ! grep -q 'NVM_DIR' "$HOME/.zshrc" 2>/dev/null; then
+    cat >> "$HOME/.zshrc" << 'NVMEOF'
+
+# NVM (Node Version Manager)
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+NVMEOF
+    echo "Added NVM configuration to ~/.zshrc"
+fi
+
 # Install Node.js 22 via NVM
 echo "Installing Node.js 22 via NVM..."
 nvm install 22

--- a/shared/ensure_node.sh
+++ b/shared/ensure_node.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# Shared Node.js PATH Helper
+#
+# Sources NVM/fnm if node is not already in PATH.
+# Should be sourced (not executed) by scripts that need Node.js.
+#
+# Usage:
+#   source "$(dirname "$0")/../shared/ensure_node.sh"
+#
+# After sourcing, `command -v node` will succeed if Node.js is installed
+# via NVM, fnm, Homebrew, or system package manager.
+#
+
+# Guard against direct execution
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    echo "This script must be sourced, not executed directly." >&2
+    exit 1
+fi
+
+# Already available — nothing to do
+if command -v node &> /dev/null; then
+    return 0 2>/dev/null || true
+fi
+
+# Try NVM
+if [ -z "${NVM_DIR:-}" ]; then
+    export NVM_DIR="${HOME}/.nvm"
+fi
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+    # shellcheck source=/dev/null
+    \. "$NVM_DIR/nvm.sh"
+    if command -v node &> /dev/null; then
+        return 0 2>/dev/null || true
+    fi
+fi
+
+# Try fnm
+if command -v fnm &> /dev/null; then
+    eval "$(fnm env)"
+    if command -v node &> /dev/null; then
+        return 0 2>/dev/null || true
+    fi
+fi
+
+# Try Homebrew node (macOS)
+if [ -d "/opt/homebrew/opt/node/bin" ]; then
+    export PATH="/opt/homebrew/opt/node/bin:$PATH"
+    if command -v node &> /dev/null; then
+        return 0 2>/dev/null || true
+    fi
+fi
+if [ -d "/usr/local/opt/node/bin" ]; then
+    export PATH="/usr/local/opt/node/bin:$PATH"
+    if command -v node &> /dev/null; then
+        return 0 2>/dev/null || true
+    fi
+fi
+
+# Try Volta
+if [ -d "${VOLTA_HOME:-$HOME/.volta}/bin" ]; then
+    export PATH="${VOLTA_HOME:-$HOME/.volta}/bin:$PATH"
+    if command -v node &> /dev/null; then
+        return 0 2>/dev/null || true
+    fi
+fi

--- a/shared/post_code_checks.sh
+++ b/shared/post_code_checks.sh
@@ -24,6 +24,13 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     exit 1
 fi
 
+# Ensure Node.js is in PATH (sources NVM/fnm if needed)
+SHARED_DIR_SELF="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=ensure_node.sh
+if [ -f "$SHARED_DIR_SELF/ensure_node.sh" ]; then
+    source "$SHARED_DIR_SELF/ensure_node.sh"
+fi
+
 # Defaults
 MAX_TEST_TIME="${MAX_TEST_TIME:-120}"
 FILE_PATH="${FILE_PATH:-}"

--- a/shared/post_task_checks.sh
+++ b/shared/post_task_checks.sh
@@ -23,6 +23,13 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     exit 1
 fi
 
+# Ensure Node.js is in PATH (sources NVM/fnm if needed)
+SHARED_DIR_SELF="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=ensure_node.sh
+if [ -f "$SHARED_DIR_SELF/ensure_node.sh" ]; then
+    source "$SHARED_DIR_SELF/ensure_node.sh"
+fi
+
 # Defaults
 MAX_TEST_TIME="${MAX_TEST_TIME:-300}"
 


### PR DESCRIPTION
## Summary
This PR introduces a shared Node.js PATH helper script and updates installation and hook scripts to ensure Node.js is available in the PATH, regardless of how it was installed (NVM, fnm, Homebrew, Volta, or system package manager).

## Key Changes

- **New `shared/ensure_node.sh`**: A reusable helper script that intelligently sources NVM, fnm, or adds Homebrew/Volta paths to make Node.js available in the current shell session. Includes guards against direct execution and early returns once Node.js is found.

- **Updated macOS installation (`Terminal/install_macos.sh`)**:
  - Ensures `.zshrc` exists before NVM installer runs
  - Explicitly adds NVM configuration to `.zshrc` (the NVM installer may only update `.bashrc`)

- **Updated Ubuntu installation (`Terminal/install_ubuntu24.sh`)**:
  - Adds NVM configuration to `.zshrc` if zsh is installed

- **Updated skill and MCP installers**:
  - `ClaudeCode/install_skills.sh`
  - `Kiro/install_mcps.sh`
  - `OpenCode/install_mcps.sh`
  - All now source `ensure_node.sh` to guarantee Node.js availability before running npm commands

- **Updated hook installers**:
  - `ClaudeCode/install_hooks.sh`
  - `Kiro/install_hooks.sh`
  - `OpenCode/install_hooks.sh`
  - All now source `ensure_node.sh` before setting up git hooks

- **Updated shared check scripts**:
  - `shared/post_code_checks.sh`
  - `shared/post_task_checks.sh`
  - Both now source `ensure_node.sh` to ensure Node.js is available during post-execution checks

## Implementation Details

The `ensure_node.sh` helper follows a fallback strategy:
1. Returns immediately if Node.js is already in PATH
2. Attempts to load NVM from `~/.nvm`
3. Falls back to fnm if available
4. Checks Homebrew installation paths (both Apple Silicon and Intel)
5. Finally checks Volta installation path

This approach ensures compatibility across different Node.js installation methods and development environments.

https://claude.ai/code/session_01BM6eHjW5hpCmhP9gcj6VC4